### PR TITLE
Updated Icon in pricing cards

### DIFF
--- a/lib/ui_components/pricing_cards/All Pricing Cards/pricing_card/pricing_cards1.dart
+++ b/lib/ui_components/pricing_cards/All Pricing Cards/pricing_card/pricing_cards1.dart
@@ -7,7 +7,11 @@ class PricingCard1 extends StatefulWidget {
       required this.supportingText,
       required this.price,
       required this.period,
-      required this.details, required this.cardColor, required this.textColor, required this.buttonColor, required this.buttonTextColor});
+      required this.details,
+      required this.cardColor,
+      required this.textColor,
+      required this.buttonColor,
+      required this.buttonTextColor});
   final Color cardColor;
   final Color textColor;
   final Color buttonTextColor;
@@ -118,7 +122,9 @@ class _PricingCard1State extends State<PricingCard1> {
                             ),
                           ),
                           Icon(
-                            Icons.keyboard_arrow_down_outlined,
+                            detailsTapped == false
+                                ? Icons.keyboard_arrow_down_outlined
+                                : Icons.keyboard_arrow_up_outlined,
                             color: widget.textColor,
                           ),
                         ],


### PR DESCRIPTION

**Description:**

 Changed the arrow down icon besides the details text to arrow up icon when the details screen is expanded/clicked.

This closes https://github.com/Clueless-Community/Spectrum-UI/issues/156 issue


**Changes Made:**

Added a condition statement if the details is not tapped/expanded arrow down key is rendered otherwise if tapped/expanded arrow up key is rendered.

**Screenshots/GIFs:**

### Before
![Screenshot 2023-05-20 223632](https://github.com/Clueless-Community/Spectrum-UI/assets/67851435/046094cf-7008-49f0-8a80-ae2857919fce)

### After
![Screenshot 2023-05-20 223544](https://github.com/Clueless-Community/Spectrum-UI/assets/67851435/5da34d44-b9ce-4500-8553-0fcce19fca93)



**Testing Done:**

Verified the working of the above


**Checklist:**

- [x] The code follows the project's coding style guidelines.
- [x] Unit tests have been added or updated to cover the changes.
- [x] Documentation, if applicable, has been updated to reflect the changes.
- [x] All new and existing tests pass successfully.

Please review and merge this PR at your earliest convenience.

Thank you!

