### PR TITLE
Update analysis_options.yaml

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,9 +1,5 @@
 # This file configures the analyzer, which statically analyzes Dart code to
 # check for errors, warnings, and lints.
-#
-# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
-# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
-# invoked from the command line by running `flutter analyze`.
 
 # The following line activates a set of recommended lints for Flutter apps,
 # packages, and plugins designed to encourage good coding practices.
@@ -15,15 +11,16 @@ linter:
   # included above or to enable additional rules. A list of all available lints
   # and their documentation is published at
   # https://dart-lang.github.io/linter/lints/index.html.
-  #
-  # Instead of disabling a lint rule for the entire project in the
-  # section below, it can also be suppressed for a single line of code
-  # or a specific dart file by using the `// ignore: name_of_lint` and
-  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
-  # producing the lint.
+
   rules:
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+    # Disable the `avoid_print` rule
+    avoid_print: false
+
+    # Enable the `prefer_single_quotes` rule
+    prefer_single_quotes: true
+
+    # Add more custom rules here if needed
+    # custom_rule_name: true
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options


### PR DESCRIPTION
This updated configuration:

Keeps the existing include directive for the package:flutter_lints/flutter.yaml file to activate recommended Flutter-specific lints.

Under the linter section, you can customize the lint rules for your project. It disables the avoid_print rule and enables the prefer_single_quotes rule as an example. You can add or modify rules according to your project's coding standards.

You can also add any custom lint rules specific to your project by following the same format (custom_rule_name: true).

To apply this updated configuration, save it to your project's analysis_options.yaml file or the equivalent configuration file you are using. The Dart analyzer will use this configuration when running flutter analyze or any other analysis tool.

### Pull Request Template

**Description:**

Briefly describe the purpose and context of this pull request.

**Changes Made:**

Provide a clear and concise overview of the specific changes made in this PR.

**Related Issue:**

If applicable, reference the related issue number(s) here.

**Screenshots/GIFs:**

If applicable, include any relevant screenshots or GIFs to visually demonstrate the changes.

**Testing Done:**

Outline the testing steps you have taken to ensure the changes function as intended.

**Additional Notes:**

Add any additional information or notes that are relevant to this PR.

**Checklist:**

- [ ] The code follows the project's coding style guidelines.
- [ ] Unit tests have been added or updated to cover the changes.
- [ ] Documentation, if applicable, has been updated to reflect the changes.
- [ ] All new and existing tests pass successfully.

Please review and merge this PR at your earliest convenience.

Thank you!

